### PR TITLE
Use local storage to store group collapse state

### DIFF
--- a/src/main/webapp/sectionToggle.js
+++ b/src/main/webapp/sectionToggle.js
@@ -52,7 +52,7 @@ function showJobGroup(handle, viewName, group) {
 }
 
 function getGroupStates(viewName) {
-	var stateCookie = YAHOO.util.Cookie.get("jenkins.categorized-view-collapse-state_"+viewName);
+	var stateCookie = localStorage.getItem("jenkins.categorized-view-collapse-state_"+viewName);
 	if (stateCookie == null)
 		return {};
 	return JSON.parse(stateCookie);
@@ -72,5 +72,5 @@ function setGroupState(viewName, groupName, state)
 {
 	var groupStates = getGroupStates(viewName)
 	groupStates[groupName]=state
-	YAHOO.util.Cookie.set("jenkins.categorized-view-collapse-state_"+viewName, Object.toJSON(groupStates));
+	localStorage.setItem("jenkins.categorized-view-collapse-state_"+viewName, Object.toJSON(groupStates));
 }


### PR DESCRIPTION
Storing it in cookies causes "Bad Message 431 reason: Request Header Fields Too
Large" when there are many jobs.

Fixes #18

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>