### PR TITLE
Remove compatibleSinceVersion from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 	<properties>
 		<jenkins.version>2.249.1</jenkins.version>
 		<java.level>8</java.level>
-		<hpi.compatibleSinceVersion>2.249.1</hpi.compatibleSinceVersion>
 	</properties>
 
 	<artifactId>categorized-view</artifactId>


### PR DESCRIPTION
This was mistakenly added to indicate the minimum required Jenkins version, but causes a data upgrade message to be shown in the Jenkins plugin manager instead (the jenkins.version property indicates the minimum required Jenkins version and is correct). Remove it.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
