### PR TITLE
Simplify JSON parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <revision>1.14</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/main/webapp/sectionToggle.js
+++ b/src/main/webapp/sectionToggle.js
@@ -69,5 +69,5 @@ function getGroupState(viewName, groupName) {
 function setGroupState(viewName, groupName, state) {
     var groupStates = getGroupStates(viewName)
     groupStates[groupName] = state
-    localStorage.setItem("jenkins.categorized-view-collapse-state_" + viewName, Object.toJSON ? Object.toJSON(groupStates) : JSON.stringify(groupStates));
+    localStorage.setItem("jenkins.categorized-view-collapse-state_" + viewName, JSON.stringify(groupStates));
 }


### PR DESCRIPTION
Now that Prototype.js has been removed in 2.426.x, we can remove the no-longer needed `Object.toJSON` workaround.

### Testing done

`mvn clean verify -DskipTests`