### PR TITLE
JDK 21 on linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
This is one of plugin improvements to be reade for 'modern' develepmonet
see also:
https://www.jenkins.io/doc/developer/tutorial-improve/

Use JDK 21 on linux platforms as required in
https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/

### Testing done

Only automated tests will be executed

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~~[ ] Link to relevant issues in GitHub or Jira~~
- ~~[ ] Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
