### PR TITLE
Fix column links for jobs from folders

### DIFF
--- a/src/main/resources/lib/categorizedview/nestedProjectsView.jelly
+++ b/src/main/resources/lib/categorizedview/nestedProjectsView.jelly
@@ -38,6 +38,8 @@ THE SOFTWARE.
       <!-- project list -->
       <table id="projectstatus_${job.name}" class="pane bigtable">
         <j:forEach var="job" items="${jobs}">
+          <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
+          <j:set var="jobBaseUrl" value="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>
           <tr id="job_${job.name}" class="${job.disabled?'disabledJob':null}">
             <j:forEach var="col" items="${columnExtensions}">
               <st:include page="column.jelly" it="${col}"/>


### PR DESCRIPTION
When using the Categorized View Plugin with jobs from a folder structure (e.g. from [Bitbucket Branch Source Plugin](https://plugins.jenkins.io/cloudbees-bitbucket-branch-source/)), the generated links in various columns (e.g. "Last Success / Last Failure / Schedule Build") would be generated as follows, which points to no valid job at all:

_https://${jenkins-url}/view/${my-categorized-view}/job/feature%2F1234/lastFailedBuild/_

Instead, the expected link to be generated would look like this:

_https:/${jenkins-url}/view/${my-categorized-view}/job/testproject/job/testrepo/job/feature%2F1234/lastFailedBuild/_

![image](https://github.com/user-attachments/assets/4b25a146-d5d4-4fbe-96f6-fd11f108a78f)

This PR aims to fix this behaviour.

### Testing done

Manual steps to reproduce:
- Start Jenkins from workspace with `mvn hpi:run`
- Create a folder structure with one or multiple jobs in it (manual, with Multibranch Pipelines, etc.)
- Create a Categorized Jobs View with a Regex Grouping Rule matching one or multiple jobs
- Inspect the column links for e.g. "Last Success", "Last Failure" and "Schedule build" 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
~~- [ ] Link to relevant issues in GitHub or Jira~~
~~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
