### PR TITLE
Use a single table instead of nested tables to better display column …

### DIFF
--- a/src/main/resources/lib/categorizedview/catProjectViewRow.jelly
+++ b/src/main/resources/lib/categorizedview/catProjectViewRow.jelly
@@ -54,11 +54,6 @@ THE SOFTWARE.
         <st:nbsp/>
       </td>
     </tr>
-    <tr id="jobNestedItems_${job.name}" class="${view.getGroupClassFor(job)} categoryJobs" category="${job.name}" categoryRole="child">
-      <td><st:nbsp/></td>
-      <td colspan="${columnExtensions.size()+1}" class="categoryJobsColumn">
-        <c:nestedProjectsView jobs="${job.groupItems}" />
-      </td>
-    </tr>
+    <c:nestedProjectsView parentJob="${job}" jobs="${job.groupItems}" />
   </j:if>
 </j:jelly>

--- a/src/main/resources/lib/categorizedview/nestedProjectsView.jelly
+++ b/src/main/resources/lib/categorizedview/nestedProjectsView.jelly
@@ -28,28 +28,29 @@ THE SOFTWARE.
   <st:documentation>
     Renders a list of grouped jobs.
 
+    <st:attribute name="parentJob" use="required">
+      Parent item.
+    </st:attribute>
     <st:attribute name="jobs" use="required" trim="Collection">
       Items to show.
     </st:attribute>
   </st:documentation>
 
-  <div class="dashboard">
-    <j:if test="${!empty(jobs) or !empty(attrs.views)}">
-      <!-- project list -->
-      <table id="projectstatus_${job.name}" class="pane bigtable">
-        <j:forEach var="job" items="${jobs}">
-          <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
-          <j:set var="jobBaseUrl" value="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>
-          <tr id="job_${job.name}" class="${job.disabled?'disabledJob':null}">
-            <j:forEach var="col" items="${columnExtensions}">
-              <st:include page="column.jelly" it="${col}"/>
-            </j:forEach>
-            <td>
-              <st:nbsp/>
-            </td>
-          </tr>
+  <j:if test="${!empty(jobs) or !empty(attrs.views)}">
+    <j:forEach var="job" items="${jobs}">
+      <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
+      <j:set var="jobBaseUrl" value="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>
+      <tr id="job_${job.name}" class="${job.disabled?'disabledJob':null} ${view.getGroupClassFor(parentJob)} childJobRow" category="${parentJob.name}" categoryRole="child" data-jobgroup="${view.getGroupClassFor(parentJob)}">
+        <td>
+          <st:nbsp/>
+        </td>
+        <j:forEach var="col" items="${columnExtensions}">
+          <st:include page="column.jelly" it="${col}"/>
         </j:forEach>
-      </table>
-    </j:if>
-  </div>
+        <td>
+          <st:nbsp/>
+        </td>
+      </tr>
+    </j:forEach>
+  </j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/categorizedview/IndentedJobColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/categorizedview/IndentedJobColumn/column.jelly
@@ -26,7 +26,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 <j:if test="${!view.isGroupTopLevelItem(job)}">
     <td style="${indenter.getCss(job)}">
-        <a href="${rootURL}/${job.url}" class='jenkins-table__link model-link inside'> <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/></a>
+        <a href="${rootURL}/${job.url}" class='jenkins-table__link model-link inside'>
+            <span>
+                <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
+            </span>
+        </a>
     </td>
 </j:if>
 <j:if test="${view.isGroupTopLevelItem(job)}">

--- a/src/main/webapp/catSortable.css
+++ b/src/main/webapp/catSortable.css
@@ -5,26 +5,7 @@ tr.categoryJobRow {
   cursor: pointer;
 }
 
-.jenkins-table > tbody > tr > td.categoryJobsColumn {
-  padding-left: 2em; 
-  padding-top: 0; 
-  padding-bottom: 0;
-}
-
-td.categoryJobsColumn > div.dashboard > table > tbody > tr {
-  border-bottom: 0;
-}
-
-td.categoryJobsColumn > div.dashboard > table > tbody > tr > td {
+tr.childJobRow > td {
   font-weight: 500;
-  border-bottom: 0;
+  padding-left: 4em !important;
 }
-
-td.categoryJobsColumn > div.dashboard > table > tbody > tr:first-child > td {
-  border-top: 0;
-}
-
-td.categoryJobsColumn > div.dashboard > table > tbody > tr > td {
-  border-top: 2px solid var(--table-background);
-}
-

--- a/src/main/webapp/catSortable.js
+++ b/src/main/webapp/catSortable.js
@@ -212,10 +212,7 @@ var CategorizedSortable = (function () {
                 var aCategory = a.getAttribute("category");
                 var bCategory = b.getAttribute("category");
                 if (aCategory != null && aCategory == bCategory) {
-                    if (a.getAttribute("categoryRole") == "category")
-                        return -1;
-                    else
-                        return 1;
+                    return -1;
                 }
 
                 return s(this.extractData(aCell),
@@ -233,8 +230,9 @@ var CategorizedSortable = (function () {
         },
 
         getCell: function (a, columnNumber) {
-            if (a.id.match(/^jobNestedItems_/)) {
-                var groupId = "category_" + a.id.replace(/^jobNestedItems_/, "");
+            if (a.id.match(/^job_/)) {
+                var groupId = "category_" + a.getAttribute("category");
+                console.log("GROUP ID " + groupId);
                 var categoryRow = document.getElementById(groupId);
                 return categoryRow.cells[columnNumber]
             }


### PR DESCRIPTION
This PR fixes #110, https://issues.jenkins.io/browse/JENKINS-29273 and https://issues.jenkins.io/browse/JENKINS-24723 by using a single table for all jobs instead of nested tables.

**Before:**
![grafik](https://github.com/user-attachments/assets/8303b092-b0e6-4644-a690-d56f947a65de)


**After:**
![grafik](https://github.com/user-attachments/assets/85bfb173-f453-4554-be45-0edc93185da5)

### Testing done

Manual testing:
- Expanding and collapsing categories
- Sorting by column
- Identation of jobs with very long names

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed